### PR TITLE
NewRecipientPage: populate phone number on contact added

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+messaging-app (0.1.2~0ubports1) xenial; urgency=medium
+
+  * Fix adding of a new contact
+    (https://github.com/ubports/ubuntu-touch/issues/878)
+
+ -- Alberto Mardegan <mardy@users.sourceforge.net>  Fri, 14 Sep 2018 00:19:06 +0300
+
 messaging-app (0.1.1+ubports1) xenial; urgency=medium
 
   [ Gustavo Pichorim Boiko ]

--- a/src/qml/NewRecipientPage.qml
+++ b/src/qml/NewRecipientPage.qml
@@ -50,7 +50,7 @@ Page {
         mainStack.removePages(newRecipientPage)
     }
 
-    function createEmptyContactWithAccount(account, parent)
+    function createEmptyContact(account, parent)
     {
         var details = [ {detail: "EmailAddress", field: "emailAddress", value: ""},
                         {detail: "Name", field: "firstName", value: ""}
@@ -66,10 +66,15 @@ Page {
             newContact.addDetail(newDetail)
         }
 
-        var accountSourceTemplate = "import QtContacts 5.0; OnlineAccount{ accountUri: \"%1\"; protocol: %2 }"
-        var newDetail = Qt.createQmlObject(accountSourceTemplate
-                                           .arg(account.uri)
-                                           .arg(account.protocol), parent)
+        if (account.protocol === "OnlineAccount.Unknown") {
+            var phoneSourceTemplate = "import QtContacts 5.0; PhoneNumber{ number: \"" + account.uri + "\" }"
+            var newDetail = Qt.createQmlObject(phoneSourceTemplate, parent)
+        } else {
+            var accountSourceTemplate = "import QtContacts 5.0; OnlineAccount{ accountUri: \"%1\"; protocol: %2 }"
+            var newDetail = Qt.createQmlObject(accountSourceTemplate
+                                               .arg(account.uri)
+                                               .arg(account.protocol), parent)
+        }
         newContact.addDetail(newDetail)
         return newContact
     }
@@ -226,11 +231,11 @@ Page {
         }
 
         onAddNewContactClicked: {
-            var newContact = newRecipientPage.createEmptyContactWithAccount(newRecipientPage.accountToAdd, newRecipientPage)
+            var newContact = newRecipientPage.createEmptyContact(newRecipientPage.accountToAdd, newRecipientPage)
             var focusField = "name"
             if (newRecipientPage.accountToAdd) {
                 switch (newRecipientPage.accountToAdd.protocol) {
-                case "ofono":
+                case "OnlineAccount.Unknown":
                     focusField = "phones"
                     break
                 default:


### PR DESCRIPTION
The existing code is taken from the staging branch, which was obviously
not properly tested. When adding a contact, if the account type is a
cellular one ("OnlineAccount.Unknown"), then the URI carries the phone
number.

Fixes: https://github.com/ubports/ubuntu-touch/issues/878