### PR TITLE
Remove unnecessary list item highlights

### DIFF
--- a/src/qml/Messages.qml
+++ b/src/qml/Messages.qml
@@ -855,7 +855,6 @@ Page {
                 anchors {
                     left: parent ? parent.left : undefined
                     right: parent ? parent.right : undefined
-                    rightMargin: units.gu(2)
                     top: parent ? parent.top: undefined
                     topMargin: units.gu(1)
                 }

--- a/src/qml/Messages.qml
+++ b/src/qml/Messages.qml
@@ -855,6 +855,7 @@ Page {
                 anchors {
                     left: parent ? parent.left : undefined
                     right: parent ? parent.right : undefined
+                    rightMargin: units.gu(2)
                     top: parent ? parent.top: undefined
                     topMargin: units.gu(1)
                 }

--- a/src/qml/NewRecipientPage.qml
+++ b/src/qml/NewRecipientPage.qml
@@ -206,7 +206,7 @@ Page {
 
         focus: true
         currentIndex: -1
-        highlightSelected: true
+        highlightSelected: false
         activeFocusOnTab: true
         showAddNewButton: true
         showImportOptions: (contactList.count === 0) && (filterTerm == "")

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -283,7 +283,7 @@ Page {
         }
     }
 
-    UbuntuListView {
+    ListView {
         id: settingsList
 
         currentIndex: -1


### PR DESCRIPTION
This removes the list item highlights in the settings page and new recipient page.

Note: This is just my opinion because it seems like they are unnecessary and doesn't look good.
They would make sense if the list item contents are displayed in an additional column (adaptivelayout) but that doesn't seem to be the case at the moment.