### PR TITLE
Really remove the leadingActions for real

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+messaging-app (0.1.3~0ubports0) xenial; urgency=medium
+
+  * Removed leadingActions from MessagingContactViewPage
+    (https://github.com/ubports/messaging-app/pull/53)
+
+ -- Dalton Durst <dalton@ubports.com>  Sun, 25 Nov 2018 13:12:21 -0600
+
 messaging-app (0.1.2~0ubports1) xenial; urgency=medium
 
   * Fix adding of a new contact

--- a/src/qml/MessagingContactViewPage.qml
+++ b/src/qml/MessagingContactViewPage.qml
@@ -78,18 +78,6 @@ ContactViewPage {
             }
         }
     }
-    
-    leadingActions: [
-        Action {
-            objectName: "cancel"
-
-            text: i18n.tr("Cancel")
-            iconName: "back"
-            shortcut: "Esc"
-            onTriggered: pageStack.removePages(root)
-        }
-
-    ]
 
     headerActions: [
         Action {


### PR DESCRIPTION
Seems like commit https://github.com/ubports/messaging-app/commit/42cc75ce35d607764bc03b82a7f97a645d651b65 added the leadingActions back. This PR removes leadingActions and updates the changelog so it gets installed.