### PR TITLE
Group MMS swipe lock fix

### DIFF
--- a/src/qml/AttachmentsDelegate.qml
+++ b/src/qml/AttachmentsDelegate.qml
@@ -35,11 +35,11 @@ Column {
     property bool isMultimedia: false
     property bool swipeLocked: {
         for (var i=0; i < attachmentsView.children.length; i++) {
-            if (attachmentsView.children[i].item && !attachmentsView.children[i].item.swipeLocked) {
-                return false
+            if (attachmentsView.children[i].item && attachmentsView.children[i].item.swipeLocked) {
+                return true
             }
         }
-        return true
+        return false
     }
     property string messageText: ""
     property var lastItem: children.length > 0 ? children[children.length - 1] : null


### PR DESCRIPTION
Simple fix reversing the swipeLocked logic on attachements (always true unless specified false). Tested on Nexus 5 hammerhead. Issue mentioned here: https://github.com/ubports/messaging-app/issues/128