### PR TITLE
fix minor warning messages

### DIFF
--- a/src/qml/ComposeBar.qml
+++ b/src/qml/ComposeBar.qml
@@ -65,7 +65,7 @@ Item {
     property int smsLength: 160
 
     Component.onDestruction: {
-        messageTextField.draftKey = ""
+        messageTextArea.draftKey = ""
         composeBar.reset()
     }
 

--- a/src/qml/MainPage.qml
+++ b/src/qml/MainPage.qml
@@ -273,7 +273,8 @@ Page {
 
             function show()
             {
-                var properties = model.properties
+                var properties = {}
+                properties["accountId"] = model.properties.accountId
                 properties["keyboardFocus"] = false
                 properties["threads"] = model.threads
                 properties["presenceRequest"] = threadDelegate.presenceItem
@@ -281,9 +282,6 @@ Page {
                     properties["scrollToEventId"] = displayedEvent.eventId
                 }
                 properties["chatEntry"] = chatEntry
-                delete properties["participants"]
-                delete properties["localPendingParticipants"]
-                delete properties["remotePendingParticipants"]
                 mainView.showMessagesView(properties)
             }
 

--- a/src/qml/MessageBubble.qml
+++ b/src/qml/MessageBubble.qml
@@ -144,7 +144,6 @@ BorderImage {
             left: parent.left
             leftMargin: units.gu(1)
         }
-        //width: paintedWidth > maxDelegateWidth ? maxDelegateWidth : undefined
         fontSize: "medium"
         height: contentHeight
         onLinkActivated:  Qt.openUrlExternally(link)

--- a/src/qml/MessageBubble.qml
+++ b/src/qml/MessageBubble.qml
@@ -144,7 +144,7 @@ BorderImage {
             left: parent.left
             leftMargin: units.gu(1)
         }
-        width: paintedWidth > maxDelegateWidth ? maxDelegateWidth : undefined
+        //width: paintedWidth > maxDelegateWidth ? maxDelegateWidth : undefined
         fontSize: "medium"
         height: contentHeight
         onLinkActivated:  Qt.openUrlExternally(link)
@@ -153,6 +153,13 @@ BorderImage {
         wrapMode: Text.Wrap
         color: root.messageIncoming ? Theme.palette.normal.backgroundText :
                                       Theme.palette.normal.positiveText
+        Component.onCompleted: {
+                if (textLabel.paintedWidth > maxDelegateWidth) {
+                    width = maxDelegateWidth
+                } else {
+                    width = undefined
+                }
+            }
     }
 
     Row {


### PR DESCRIPTION
This is all that i can do for now :-|, there are plenty of other warnings when selecting a Thread, but changing the code in MessagesListView can break things easily.
"Lots of `file:///usr/lib/arm-linux-gnueabihf/qt5/qml/Ubuntu/Components/1.3/AdaptivePageLayout.qml:708:9: QML PageWrapper: Could not assign value: ... to property: ...
` [EDIT] => fixed by last commit
Don't get why we have bindings here and pass the Loader to the delegate : https://github.com/ubports/messaging-app/blob/xenial/src/qml/MessagesListView.qml#L94-L98

Also don't know what `HistoryThreadModel.MessageTypeInformation` is for ?