### PR TITLE
hide OSK whe previewing images

### DIFF
--- a/src/qml/AttachmentsDelegate.qml
+++ b/src/qml/AttachmentsDelegate.qml
@@ -57,6 +57,7 @@ Column {
             properties["attachment"] = attachment.item.attachment
             properties["thumbnail"] = attachment.item
             mainStack.addPageToCurrentColumn(messages, Qt.resolvedUrl(attachment.item.previewer), properties)
+            Qt.inputMethod.hide()
         }
     }
 


### PR DESCRIPTION
This is to avoid having the OSK displayed while we are previewing attachments