### PR TITLE
fix item being displayed at wrong position when updating a Thread.

### DIFF
--- a/po/messaging-app.pot
+++ b/po/messaging-app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-01-30 12:22+0000\n"
+"POT-Creation-Date: 2020-03-10 12:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -492,7 +492,7 @@ msgstr ""
 msgid "New MMS Group"
 msgstr ""
 
-#: ../src/qml/MainPage.qml:117 ../src/qml/MainPage.qml:253
+#: ../src/qml/MainPage.qml:117 ../src/qml/MainPage.qml:263
 msgid "New message"
 msgstr ""
 

--- a/src/qml/MainPage.qml
+++ b/src/qml/MainPage.qml
@@ -226,6 +226,16 @@ Page {
         }
     }
 
+     NumberAnimation {
+            id:threadMoveAnim
+            running: threadList.currentIndex == 0
+            target: threadList.currentItem;
+            properties: "opacity";
+            duration: 500
+            easing.type: Easing.InOutQuad;
+            from: 0; to:1
+        }
+
     MultipleSelectionListView {
         id: threadList
         objectName: "threadList"
@@ -267,28 +277,7 @@ Page {
                 mainPage._keepFocus = true
             }
         }
-//commented for now due to wrong behavior ( the first delegate will appear out of the list after any model update ),see https://bugreports.qt.io/browse/QTBUG-49868
-//
-//        displaced: Transition {
-//            NumberAnimation {
-//                property: "y"
-//            }
-//        }
 
-
-//        remove: Transition {
-//            ParallelAnimation {
-//                NumberAnimation {
-//                    property: "height"
-//                    to: 0
-//                }
-
-//                NumberAnimation {
-//                    properties: "opacity"
-//                    to: 0
-//                }
-//            }
-//        }
 
         listDelegate: ThreadDelegate {
             id: threadDelegate
@@ -362,6 +351,12 @@ Page {
 
 
             opacity: !groupChat || chatEntry.active ? 1.0 : 0.5
+
+            ListView.onRemove: SequentialAnimation {
+                PropertyAction { target: threadDelegate; property: "ListView.delayRemove"; value: true }
+                NumberAnimation { target: threadDelegate; property: "height"; to: 0; duration: 250; easing.type: Easing.InOutQuad }
+                PropertyAction { target: threadDelegate; property: "ListView.delayRemove"; value: false }
+            }
         }
         onSelectionDone: {
             var threadsToRemove = []

--- a/src/qml/MainPage.qml
+++ b/src/qml/MainPage.qml
@@ -267,27 +267,28 @@ Page {
                 mainPage._keepFocus = true
             }
         }
+//commented for now due to wrong behavior ( the first delegate will appear out of the list after any model update ),see https://bugreports.qt.io/browse/QTBUG-49868
+//
+//        displaced: Transition {
+//            NumberAnimation {
+//                property: "y"
+//            }
+//        }
 
-        displaced: Transition {
-            NumberAnimation {
-                property: "y"
-            }
-        }
 
+//        remove: Transition {
+//            ParallelAnimation {
+//                NumberAnimation {
+//                    property: "height"
+//                    to: 0
+//                }
 
-        remove: Transition {
-            ParallelAnimation {
-                NumberAnimation {
-                    property: "height"
-                    to: 0
-                }
-
-                NumberAnimation {
-                    properties: "opacity"
-                    to: 0
-                }
-            }
-        }
+//                NumberAnimation {
+//                    properties: "opacity"
+//                    to: 0
+//                }
+//            }
+//        }
 
         listDelegate: ThreadDelegate {
             id: threadDelegate


### PR DESCRIPTION
fixes https://github.com/ubports/messaging-app/issues/161 

As Transition Animation is causing the issue of bad item positioning, let comment it out and replace it by basic Animation for now.
Currently we can reproduce this bug when message takes time to be sent and we go back before to the Thread List. But also with the next PR for drafts, it can be reproduced each time.

This is a known bug with Transition animations when having sections https://bugreports.qt.io/browse/QTBUG-49868 