### PR TITLE
remove "received" label and use "sent" now

### DIFF
--- a/src/qml/MessageInfoDialog.qml
+++ b/src/qml/MessageInfoDialog.qml
@@ -142,14 +142,7 @@ Item {
                 text: root.activeMessage ?
                           "<b>%1:</b> %2".arg(i18n.tr("Sent")).arg(Qt.formatDateTime(root.activeMessage.timestamp, Qt.DefaultLocaleShortDate)) :
                           ""
-                visible: root.activeMessage && (root.activeMessage.senderId === "self")
-            }
-
-            Label {
-                text: root.activeMessage ?
-                          "<b>%1:</b> %2".arg(i18n.tr("Received")).arg(Qt.formatDateTime(root.activeMessage.timestamp, Qt.DefaultLocaleShortDate)) :
-                          ""
-                visible: (root.activeMessage && root.activeMessage.senderId !== "self")
+                visible: root.activeMessage
             }
 
             Label {


### PR DESCRIPTION
refs: https://github.com/ubports/messaging-app/issues/179
According to https://github.com/ubports/history-service/pull/13, display now the timestamp as the message sent date time: