### PR TITLE
fix wrong Type and ThreadId for new recipients

### DIFF
--- a/src/qml/Messages.qml
+++ b/src/qml/Messages.qml
@@ -232,7 +232,6 @@ Page {
         messages.participants.length = 0
         messages.participantIds.length = 0
         messages.threads = []
-        reloadFilters = !reloadFilters
     }
 
     function addNewThreadToFilter(newAccountId, properties) {
@@ -263,9 +262,10 @@ Page {
             messages.participantIds = ids;
         }
 
+        var threads = messages.threads
         if (!checkThreadInFilters(newAccountId, threadId)) {
-            messages.threads.push(thread)
-            reloadFilters = !reloadFilters
+            threads.push(thread)
+            messages.threads = threads
         }
 
         return thread
@@ -871,8 +871,9 @@ Page {
                     //cleanup the filter
                     resetFilters()
 
-                    if (recipientsIds.length === 1) { //only refresh message history for single participant, otherwise it have UI side effect (unable to add more 2 participants )
-                        addNewThreadToFilter(messages.account.accountId, {"participantIds": recipientsIds})
+                    if (recipientsIds.length === 1) {
+                        //only refresh message history for single participant, otherwise it have UI side effects (unable to add more 2 participants )
+                        addNewThreadToFilter(messages.account.accountId, {"participantIds": recipientsIds, "chatType": HistoryThreadModel.ChatTypeContact})
                     }
                 }
 


### PR DESCRIPTION
fixes #208 
Since 556d39e1d44f5174bb10ddc09fa750ddb2f8c570, when sending a message to a new single recipient, a new Thread is created with type None in database and a threadId of type "broadcast:...". This should not be the case as Telepathy report it as a type "Contact" and should not be of "broadcast" type.  This triggers annoying and useless history refreshing twice or more.

Unfortunately, new Threads previously created before this PR and since 556d39e1d44f5174bb10ddc09fa750ddb2f8c570  will still have that Type None thread. A thread delete fix the issue though