### PR TITLE
for 1 to 1 conversation, order the message by database insertion.

### DIFF
--- a/src/qml/Messages.qml
+++ b/src/qml/Messages.qml
@@ -39,6 +39,7 @@ Page {
     property string accountId: ""
     property var threadId: threads.length > 0 ? threads[0].threadId : "UNKNOWN"
     property int chatType: threads.length > 0 ? threads[0].chatType : HistoryThreadModel.ChatTypeNone
+    property bool isMmsGroupChat: account.type == AccountEntry.PhoneAccount && chatType == ChatEntry.ChatTypeRoom
     property QtObject account: getCurrentAccount()
     property variant participants: {
         if (threads.length > 0) {
@@ -450,7 +451,6 @@ Page {
             }
             eventModel.writeEvents([event]);
         } else {
-            var isMmsGroupChat = messages.account.type == AccountEntry.PhoneAccount && messages.chatType == ChatEntry.ChatTypeRoom
             // mms group chat only works if we know our own phone number
             var isSelfContactKnown = account.selfContactId != ""
             if (isMmsGroupChat && !isSelfContactKnown) {
@@ -1394,7 +1394,7 @@ Page {
         filter: updateFilters(telepathyHelper.textAccounts.all, messages.chatType, messages.participantIds, messages.reloadFilters, messages.threads)
         matchContacts: messages.account ? messages.account.addressableVCardFields.length > 0 : false
         sort: HistorySort {
-           sortField: "timestamp"
+           sortField: isMmsGroupChat ? "timestamp": "rowid"
            sortOrder: HistorySort.DescendingOrder
         }
         onCountChanged: {


### PR DESCRIPTION
As now we use the date column as the date the sms was sent. Some sms not already read may appear before in the conversation list. This is also the case where sender have a time set before the recipient . Could be annoying for a 1 to 1 conversation.
We can use the natural database insertion  order to work around that but lets keep the "timestamp" for MMSgroup.

