### PR TITLE
Revert "remove "received" label and use "sent" now ref: https://githu…

### DIFF
--- a/src/qml/MessageInfoDialog.qml
+++ b/src/qml/MessageInfoDialog.qml
@@ -142,7 +142,14 @@ Item {
                 text: root.activeMessage ?
                           "<b>%1:</b> %2".arg(i18n.tr("Sent")).arg(Qt.formatDateTime(root.activeMessage.timestamp, Qt.DefaultLocaleShortDate)) :
                           ""
-                visible: root.activeMessage
+                visible: root.activeMessage && (root.activeMessage.senderId === "self")
+            }
+
+            Label {
+                text: root.activeMessage ?
+                          "<b>%1:</b> %2".arg(i18n.tr("Received")).arg(Qt.formatDateTime(root.activeMessage.timestamp, Qt.DefaultLocaleShortDate)) :
+                          ""
+                visible: (root.activeMessage && root.activeMessage.senderId !== "self")
             }
 
             Label {


### PR DESCRIPTION

This reverts commit 06164c7f
as users report issues with sent date: see https://github.com/ubports/history-service/pull/27