### PR TITLE
fix(messagebubble.qml): prevent wrapping in the middle of words

### DIFF
--- a/src/qml/MessageBubble.qml
+++ b/src/qml/MessageBubble.qml
@@ -65,8 +65,8 @@ BorderImage {
 
         // remove html tags
         text = text.replace(/</g,'&lt;').replace(/>/g,'<tt>&gt;</tt>');
-        // preserve white space and new lines
-        text = text.replace(/\n/g, '<br>').replace(/\s/g, '&nbsp;');
+        // preserve new lines
+        text = text.replace(/\n/g, '<br>');
         // check for links
         var htmlText = BaLinkify.linkify(text);
         if (htmlText !== text) {


### PR DESCRIPTION
* Fix #212
* Reverts part of #185

As discussed with @lduboeuf on Telegram.