### PR TITLE
add animated image support

### DIFF
--- a/src/qml/AttachmentDelegates/AnimatedImageDelegate.qml
+++ b/src/qml/AttachmentDelegates/AnimatedImageDelegate.qml
@@ -1,0 +1,178 @@
+/*
+ * Copyright 2020 Ubports Foundation
+ *
+ * This file is part of messaging-app.
+ *
+ * messaging-app is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 3.
+ *
+ * messaging-app is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick 2.2
+import QtQuick.Controls 2.2
+import Ubuntu.Components 1.3
+import ".."
+
+BaseDelegate {
+    id: imageDelegate
+
+    previewer: "AttachmentDelegates/PreviewerImage.qml"
+    height: imageAttachment.height
+    width: imageAttachment.width
+
+    function calculateVisibility() {
+        // check if item is truly visible
+        var itemPosY = imageDelegate.mapToItem(messageList,0,0).y
+        var isVisible = (itemPosY >= 0 && itemPosY + imageDelegate.height <= messageList.height)
+
+        if (isVisible) {
+            // do not autoplay it twice when scrolling up and down in the same conversation
+            if (!attachment.played && mainView.autoplayAnimatedImage) {
+                imageAttachment.playing = true
+                attachment.played = true
+                // prevent from infinite playing
+                autoStopAnimation.start()
+             }
+        } else {
+            imageAttachment.playing = false
+            autoStopAnimation.stop()
+        }
+
+    }
+
+    onAttachmentChanged: {
+        if (!attachment.played) attachment.played = false
+    }
+
+    Connections {
+        target: messageList
+        onContentYChanged: {
+            // just to avoid calculation on each messageList.contentY
+            if (Math.round(messageList.contentY) % 8 === 0) {
+                calculateVisibility()
+            }
+        }
+    }
+
+    // delay the calculation at image ready to have correct positions ( needed for initial load )
+    Timer {
+        id: delayAction
+        interval: 100; running: false; repeat: false
+        onTriggered: calculateVisibility()
+    }
+
+    // autoplay will end after 10 secondes max
+    Timer {
+        id: autoStopAnimation
+        interval: 10000; running: false; repeat: false
+        onTriggered: imageAttachment.playing = false
+    }
+
+    property bool isFullyVisible: (yoff > list.y && yoff + height < list.y + list.height)
+
+
+    UbuntuShape {
+        id: bubble
+        anchors.top: parent.top
+        width: imageAttachment.width
+        height: imageAttachment.height
+
+        image: AnimatedImage {
+            id: imageAttachment
+            objectName: "imageAttachment"
+
+            fillMode: Image.PreserveAspectCrop
+            playing: false
+            source: attachment.filePath
+            asynchronous: true
+            height: units.gu(14)
+            width:units.gu(27)
+            cache: false
+
+            onStatusChanged:  {
+                if (status === Image.Error) {
+                    source = "image://theme/image-missing"
+                    width = 128
+                    height = 128
+                } else if (status == Image.Ready) {
+                    delayAction.start()
+                }
+            }
+        }
+
+        UbuntuShape {
+            id: playbackBtn
+            anchors {
+                right: imageAttachment.right
+                bottom: imageFooter.top
+                rightMargin: units.gu(1)
+            }
+            width: units.gu(3)
+            height: width
+            backgroundColor: Qt.rbga(255,255,255)
+            radius: "large"
+
+            Icon {
+                anchors.fill: parent
+                name: imageAttachment.playing ? "media-playback-pause" :  "media-playback-start"
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                onPressed: {
+                    imageAttachment.playing ? imageAttachment.playing = false: imageAttachment.playing = true
+                }
+            }
+
+        }
+
+
+        Rectangle {
+            id: imageFooter
+            visible: imageDelegate.lastItem
+            gradient: Gradient {
+                GradientStop { position: 0.0; color: "transparent" }
+                GradientStop { position: 1.0; color: "gray" }
+            }
+
+            anchors {
+                bottom: parent.bottom
+                left: parent.left
+                right: parent.right
+            }
+            height: units.gu(2)
+            radius: bubble.height * 0.1
+            Label {
+                anchors{
+                    left: parent.left
+                    bottom: parent.bottom
+                    leftMargin: incoming ? units.gu(2) : units.gu(1)
+                    bottomMargin: units.gu(0.5)
+                }
+                fontSize: "xx-small"
+                text: Qt.formatTime(timestamp).toLowerCase()
+                color: "white"
+            }
+        }
+    }
+
+    DeliveryStatus {
+       id: deliveryStatus
+       messageStatus: textMessageStatus
+       enabled: showDeliveryStatus
+       anchors {
+           right: parent.right
+           rightMargin: units.gu(0.5)
+           bottom: parent.bottom
+           bottomMargin: units.gu(0.5)
+       }
+    }
+}

--- a/src/qml/AttachmentDelegates/PreviewerImage.qml
+++ b/src/qml/AttachmentDelegates/PreviewerImage.qml
@@ -142,33 +142,25 @@ Previewer {
                     width: flickable.width * flickable.sizeScale
                     height: flickable.height * flickable.sizeScale
 
-                    Image {
+                    AnimatedImage {
                         id: image
                         objectName: "thumbnailImage"
                         anchors.fill: parent
                         asynchronous: true
                         cache: false
-                        source: "image://thumbnailer/%1".arg(attachment.filePath.toString())
-                        sourceSize {
-                            width: imageItem.thumbSize.width
-                            height: imageItem.thumbSize.height
-                        }
+                        source: attachment.filePath
                         fillMode: Image.PreserveAspectFit
                         opacity: status == Image.Ready ? 1.0 : 0.0
                         Behavior on opacity { UbuntuNumberAnimation {duration: UbuntuAnimation.FastDuration} }
                     }
 
-                    Image {
+                    AnimatedImage {
                         id: highResolutionImage
                         objectName: "highResolutionImage"
                         anchors.fill: parent
                         asynchronous: true
                         cache: false
                         source: flickable.sizeScale > 1.0 ? attachment.filePath : ""
-                        sourceSize {
-                            width: width
-                            height: height
-                        }
                         fillMode: Image.PreserveAspectFit
                     }
                 }

--- a/src/qml/AttachmentsDelegate.qml
+++ b/src/qml/AttachmentsDelegate.qml
@@ -74,9 +74,16 @@ Column {
                                       "delegateSource": "AttachmentDelegates/AudioDelegate.qml",
                                     })
             } else if (startsWith(attachment.contentType, "image/")) {
+                var imgDelegate
+                if (attachment.contentType === "image/gif" || attachment.contentType === "image/webp") {
+                    imgDelegate = "AttachmentDelegates/AnimatedImageDelegate.qml"
+                } else {
+                    imgDelegate = "AttachmentDelegates/ImageDelegate.qml"
+                }
+
                 attachmentsView.dataAttachments.push({"type": "image",
                                       "data": attachment,
-                                      "delegateSource": "AttachmentDelegates/ImageDelegate.qml",
+                                      "delegateSource": imgDelegate,
                                     })
             } else if (startsWith(attachment.contentType, "application/smil") ||
                        startsWith(attachment.contentType, "application/x-smil")) {
@@ -111,6 +118,7 @@ Column {
 
         Loader {
             id: attachmentLoader
+            property bool loaded: status === Loader.Ready
 
             states: [
                 State {
@@ -132,22 +140,22 @@ Column {
             ]
             source: modelData.delegateSource
             Binding {
-                target: attachmentLoader.item ? attachmentLoader.item : null
+                target: attachmentLoader.item
                 property: "attachment"
                 value: modelData.data
-                when: attachmentLoader.status === Loader.Ready
+                when: loaded
             }
             Binding {
-                target: attachmentLoader.item ? attachmentLoader.item : null
+                target: attachmentLoader.item
                 property: "lastItem"
                 value: attachmentsView.lastItem === attachmentLoader
-                when: attachmentLoader.status === Loader.Ready
+                when: loaded
             }
             Binding {
-                target: attachmentLoader.item ? attachmentLoader.item : null
+                target: attachmentLoader.item
                 property: "isMultimedia"
                 value: isMultimedia
-                when: attachmentLoader.status === Loader.Ready
+                when: loaded
             }
         }
     }

--- a/src/qml/MessageAlertBubble.qml
+++ b/src/qml/MessageAlertBubble.qml
@@ -37,7 +37,6 @@ ListItemWithActions{
         id: image
         source: "image://theme/mail-mark-important"
         fillMode: Image.PreserveAspectFit
-        anchors.verticalCenter: rectangle.verticalCenter
         sourceSize.height: units.gu(4)
         anchors {
             left: parent.left

--- a/src/qml/MessageDelegate.qml
+++ b/src/qml/MessageDelegate.qml
@@ -207,6 +207,10 @@ ListItemWithActions {
 
     Loader {
         id: attachmentsLoader
+
+        source: Qt.resolvedUrl("AttachmentsDelegate.qml")
+        active: attachments.length > 0
+
         property bool loaded: status === Loader.Ready
 
         anchors {
@@ -216,11 +220,6 @@ ListItemWithActions {
             leftMargin: avatarVisible ? units.gu(1) : 0
             right: parent.right
         }
-
-        source: Qt.resolvedUrl("AttachmentsDelegate.qml")
-
-        active: attachments.length > 0
-        height: item ? item.height : 0
 
         Binding {
             target: attachmentsLoader.item

--- a/src/qml/SettingsPage.qml
+++ b/src/qml/SettingsPage.qml
@@ -35,7 +35,8 @@ Page {
         "mmsEnabled": function(value) { telepathyHelper.mmsEnabled = value },
         "threadSort": function(value) { mainView.sortThreadsBy = value },
         "compactView": function(value) { mainView.compactView = value },
-        "userTheme": function(value) { mainView.userTheme = value }
+        "userTheme": function(value) { mainView.userTheme = value },
+        "autoplayAnimatedImage": function(value) { mainView.autoplayAnimatedImage = value }
         //"characterCountEnabled": function(value) { msgSettings.showCharacterCount = value }
     }
 
@@ -81,7 +82,14 @@ Page {
                    "subtitle": themeModel[mainView.userTheme],
                    "options": themeModel,
                    "setMethod": "userTheme"}
-        }
+        },
+        { "type": "boolean",
+          "data": {"name": "autoplayAnimatedImage",
+                   "description": i18n.tr("AutoPlay animated image"),
+                   "property": mainView.autoplayAnimatedImage,
+                   "activatedFuncion": null,
+                   "setMethod": "autoplayAnimatedImage"}
+        },
         /*,
         { "name": "characterCountEnabled",
           "description": i18n.tr("Show character count"),

--- a/src/qml/messaging-app.qml
+++ b/src/qml/messaging-app.qml
@@ -42,6 +42,7 @@ MainView {
     property alias compactView: globalSettings.compactView
     property alias userTheme: globalSettings.userTheme
     property alias favoriteChannels: favoriteChannelsItem
+    property alias autoplayAnimatedImage: globalSettings.autoplayAnimatedImage
 
     // private
     property var _pendingProperties: null
@@ -288,6 +289,7 @@ MainView {
         property string sortThreadsBy: "timestamp"
         property bool compactView: false
         property string userTheme: "default"
+        property bool autoplayAnimatedImage: true
     }
 
     StickerPacksModel {


### PR DESCRIPTION
fixes https://github.com/ubports/messaging-app/issues/123

Here is the proposed implementation:
Autoplay of animated image is enabled by default but can be toggled off in settings.
When opening a conversation and if we have an AnimatedImage, it starts to play for 10 seconds (apparently playing with the number of frames is not reliable on Qt, for example if we would like to play 3 times the animation)
Scroll the conversation to top will stop the animation, returning back will not launch it again.
Users still have the ability to play/pause the animation.

We cannot easily store the played/not played flag on message without the need of doing it in backend ( which is heavy in history-service, see last PR for sent time....)


