### PR TITLE
Failed MMS redownload

### DIFF
--- a/po/messaging-app.pot
+++ b/po/messaging-app.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-01 12:12+0000\n"
+"POT-Creation-Date: 2021-12-15 20:47+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,7 +53,7 @@ msgstr ""
 msgid "%1 is not Admin"
 msgstr ""
 
-#: ../src/qml/Messages.qml:1256
+#: ../src/qml/Messages.qml:1259
 #, qt-format
 msgid "%1 is typing..."
 msgstr ""
@@ -172,21 +172,25 @@ msgstr[1] ""
 msgid "Audio attachment not supported"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:96
+#: ../src/qml/SettingsPage.qml:104
+msgid "Auto display keyboard"
+msgstr ""
+
+#: ../src/qml/SettingsPage.qml:97
 msgid "AutoPlay animated image"
 msgstr ""
 
-#: ../src/qml/Messages.qml:1271
+#: ../src/qml/Messages.qml:1274
 msgid "Away"
 msgstr ""
 
 #: ../src/qml/Messages.qml:700 ../src/qml/NewRecipientPage.qml:97
-#: ../src/qml/NewRecipientPage.qml:306 ../src/qml/SettingsPage.qml:125
-#: ../src/qml/SettingsPage.qml:279
+#: ../src/qml/NewRecipientPage.qml:306 ../src/qml/SettingsPage.qml:133
+#: ../src/qml/SettingsPage.qml:287
 msgid "Back"
 msgstr ""
 
-#: ../src/qml/Messages.qml:1273
+#: ../src/qml/Messages.qml:1276
 msgid "Busy"
 msgstr ""
 
@@ -226,7 +230,7 @@ msgstr ""
 #: ../src/qml/Dialogs/InformationDialog.qml:30
 #: ../src/qml/Dialogs/NoDefaultSIMCardDialog.qml:47
 #: ../src/qml/Dialogs/NoNetworkDialog.qml:32
-#: ../src/qml/MessageInfoDialog.qml:168
+#: ../src/qml/MessageInfoDialog.qml:167
 msgid "Close"
 msgstr ""
 
@@ -243,12 +247,12 @@ msgstr ""
 msgid "Copy"
 msgstr ""
 
-#: ../src/qml/Messages.qml:1108
+#: ../src/qml/Messages.qml:1111
 #, qt-format
 msgid "Create %1 Group..."
 msgstr ""
 
-#: ../src/qml/Messages.qml:1078
+#: ../src/qml/Messages.qml:1081
 msgid "Create MMS Group..."
 msgstr ""
 
@@ -256,11 +260,11 @@ msgstr ""
 msgid "Creating Group..."
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:52
+#: ../src/qml/SettingsPage.qml:53
 msgid "Dark"
 msgstr ""
 
-#: ../src/qml/MessageAlertBubble.qml:100 ../src/qml/MessageDelegate.qml:127
+#: ../src/qml/MessageAlertBubble.qml:169 ../src/qml/MessageDelegate.qml:127
 #: ../src/qml/NewGroupPage.qml:309
 #: ../src/qml/RegularMessageDelegate_irc.qml:151
 #: ../src/qml/ThreadDelegate.qml:175
@@ -283,6 +287,10 @@ msgstr ""
 msgid "Don't show again"
 msgstr ""
 
+#: ../src/qml/MessageAlertBubble.qml:144
+msgid "Download"
+msgstr ""
+
 #: ../src/qml/ThreadDelegate.qml:354
 msgid "Draft:"
 msgstr ""
@@ -295,11 +303,11 @@ msgstr ""
 msgid "Enable"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:58
+#: ../src/qml/SettingsPage.qml:59
 msgid "Enable MMS messages"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:65
+#: ../src/qml/SettingsPage.qml:66
 msgid "Enable stickers"
 msgstr ""
 
@@ -422,7 +430,7 @@ msgstr ""
 msgid "It is not possible to send the message"
 msgstr ""
 
-#: ../src/qml/Messages.qml:1102
+#: ../src/qml/Messages.qml:1105
 msgid "Join IRC Channel..."
 msgstr ""
 
@@ -438,7 +446,7 @@ msgstr ""
 msgid "Leave group"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:51
+#: ../src/qml/SettingsPage.qml:52
 msgid "Light"
 msgstr ""
 
@@ -492,7 +500,7 @@ msgstr ""
 msgid "Multiple MMS Messages"
 msgstr ""
 
-#: ../src/qml/MessageDelegate.qml:169
+#: ../src/qml/MessageDelegate.qml:170
 msgid "Myself"
 msgstr ""
 
@@ -503,6 +511,15 @@ msgstr ""
 
 #: ../src/qml/NewGroupPage.qml:84
 msgid "New MMS Group"
+msgstr ""
+
+#: ../src/qml/MessageAlertBubble.qml:35
+#, qt-format
+msgid "New MMS message to download: size is %1KB, expires on %2"
+msgstr ""
+
+#: ../src/qml/ThreadDelegate.qml:37
+msgid "New MMS notification"
 msgstr ""
 
 #: ../src/qml/MainPage.qml:117 ../src/qml/MainPage.qml:263
@@ -533,7 +550,7 @@ msgstr ""
 msgid "Number or contact name"
 msgstr ""
 
-#: ../src/qml/Messages.qml:1269
+#: ../src/qml/Messages.qml:1272
 msgid "Offline"
 msgstr ""
 
@@ -543,15 +560,22 @@ msgstr ""
 msgid "Ok"
 msgstr ""
 
-#: ../src/qml/Messages.qml:1267
+#: ../src/qml/Messages.qml:1270
 msgid "Online"
 msgstr ""
 
-#: ../src/qml/MessageAlertBubble.qml:67 ../src/qml/ThreadDelegate.qml:37
+#: ../src/qml/MessageAlertBubble.qml:33
 msgid ""
 "Oops, there has been an error with the MMS system and this message could not "
 "be retrieved. Please ensure Cellular Data is ON and MMS settings are "
 "correct, then ask the sender to try again."
+msgstr ""
+
+#: ../src/qml/MessageAlertBubble.qml:34
+msgid ""
+"Oops, there has been an error with the MMS system and this message could not "
+"be retrieved. Please ensure Cellular Data is ON and MMS settings are "
+"correct, then tap the redownload button to try to retrieve the message again."
 msgstr ""
 
 #: ../src/qml/GroupChatInfoPage.qml:374
@@ -567,11 +591,11 @@ msgstr ""
 msgid "Pick an account to create."
 msgstr ""
 
-#: ../src/qml/Stickers/StickersPicker.qml:139
+#: ../src/qml/Stickers/StickersPicker.qml:133
 msgid "Please confirm that you want to delete all stickers in the history"
 msgstr ""
 
-#: ../src/qml/Stickers/StickersPicker.qml:139
+#: ../src/qml/Stickers/StickersPicker.qml:133
 msgid "Please confirm that you want to delete all stickers in this pack"
 msgstr ""
 
@@ -592,18 +616,18 @@ msgid ""
 "<a href=\"system_settings\">System Settings &gt; Security &amp; Privacy</a>."
 msgstr ""
 
-#: ../src/qml/MessageInfoDialog.qml:62 ../src/qml/MessageInfoDialog.qml:157
+#: ../src/qml/MessageInfoDialog.qml:62 ../src/qml/MessageInfoDialog.qml:156
 msgid "Read"
 msgstr ""
 
-#: ../src/qml/MessageInfoDialog.qml:70 ../src/qml/MessageInfoDialog.qml:150
+#: ../src/qml/MessageInfoDialog.qml:70 ../src/qml/MessageInfoDialog.qml:149
 msgid "Received"
 msgstr ""
 
 #: ../src/qml/ComposeBar.qml:203
 #: ../src/qml/Dialogs/EmptyGroupWarningDialog.qml:48
 #: ../src/qml/GroupChatInfoPage.qml:432 ../src/qml/GroupChatInfoPage.qml:436
-#: ../src/qml/Stickers/StickersPicker.qml:124
+#: ../src/qml/Stickers/StickersPicker.qml:118
 msgid "Remove"
 msgstr ""
 
@@ -684,27 +708,27 @@ msgstr ""
 msgid "Share"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:72
+#: ../src/qml/SettingsPage.qml:73
 msgid "Simplified conversation view"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:45
+#: ../src/qml/SettingsPage.qml:46
 msgid "Sort by timestamp"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:46
+#: ../src/qml/SettingsPage.qml:47
 msgid "Sort by title"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:79
+#: ../src/qml/SettingsPage.qml:80
 msgid "Sort threads"
 msgstr ""
 
-#: ../src/qml/MessageInfoDialog.qml:163
+#: ../src/qml/MessageInfoDialog.qml:162
 msgid "Status"
 msgstr ""
 
-#: ../src/qml/Stickers/StickersPicker.qml:138
+#: ../src/qml/Stickers/StickersPicker.qml:132
 msgid "Stickers"
 msgstr ""
 
@@ -724,7 +748,7 @@ msgstr ""
 msgid "Swipe to reveal actions"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:50
+#: ../src/qml/SettingsPage.qml:51
 msgid "System Theme"
 msgstr ""
 
@@ -754,7 +778,7 @@ msgstr ""
 msgid "The selected account is not available at the moment"
 msgstr ""
 
-#: ../src/qml/SettingsPage.qml:87
+#: ../src/qml/SettingsPage.qml:88
 msgid "Theme"
 msgstr ""
 
@@ -792,7 +816,7 @@ msgstr ""
 msgid "Type a name..."
 msgstr ""
 
-#: ../src/qml/Messages.qml:1258
+#: ../src/qml/Messages.qml:1261
 msgid "Typing..."
 msgstr ""
 
@@ -852,7 +876,7 @@ msgid ""
 "able to send it."
 msgstr ""
 
-#: ../src/qml/Messages.qml:1608
+#: ../src/qml/Messages.qml:1611
 msgid ""
 "You can't send messages to this group because the group is no longer active"
 msgstr ""
@@ -896,10 +920,10 @@ msgstr ""
 msgid "You were removed from this group"
 msgstr ""
 
-#: ../src/qml/Stickers/StickersPicker.qml:268
+#: ../src/qml/Stickers/StickersPicker.qml:262
 msgid "no stickers yet"
 msgstr ""
 
-#: ../src/qml/Stickers/StickersPicker.qml:309
+#: ../src/qml/Stickers/StickersPicker.qml:303
 msgid "sent stickers will appear here"
 msgstr ""

--- a/src/qml/MessageAlertBubble.qml
+++ b/src/qml/MessageAlertBubble.qml
@@ -19,6 +19,7 @@
 import QtQuick 2.9
 import Ubuntu.Components 1.3
 import Ubuntu.Contacts 0.1
+import Ubuntu.History 0.1
 import QtGraphicalEffects 1.0
 
 ListItemWithActions{
@@ -27,10 +28,60 @@ ListItemWithActions{
     property var messageData: null
     property var account: null //not used but needed to avoid error in logs
 
-    height: errorTxt.height + textTimestamp.height + units.gu(2)
+    readonly property var messageStatus: messageData.textMessageStatus
+
+    readonly property string permanentErrorText: i18n.tr("Oops, there has been an error with the MMS system and this message could not be retrieved. Please ensure Cellular Data is ON and MMS settings are correct, then ask the sender to try again.")
+    readonly property string temporaryErrorText: i18n.tr("Oops, there has been an error with the MMS system and this message could not be retrieved. Please ensure Cellular Data is ON and MMS settings are correct, then tap the redownload button to try to retrieve the message again.")
+    readonly property string mmsReceivedText: i18n.tr("New MMS message to download: size is %1KB, expires on %2")
+
+    readonly property bool permanentError: (messageData.textMessageStatus === HistoryThreadModel.MessageStatusPermanentlyFailed) || (messageData.textMessageStatus === HistoryThreadModel.MessageStatusUnknown)
+
+    height: errorTxt.height + redownloadButton.height + textTimestamp.height + units.gu(2)
     anchors {
         topMargin: units.gu(0.5)
         bottomMargin: units.gu(0.5)
+    }
+
+    /*
+      Structure of the textMessage for failed MMS message:
+
+    Code [string] - contains one of following error code:
+        x-ubports-nuntium-mms-error-unknown - unknown error, should not happen.
+        x-ubports-nuntium-mms-error-activate-context - failed first contact with MMS service & context activation. Redownload is allowed if not expired.
+        x-ubports-nuntium-mms-error-get-proxy - first contact was successful, but getting proxy failed. Very rare, should occur only with bad signal. Redownload is allowed if not expired.
+        x-ubports-nuntium-mms-error-download-content - context & proxy ok, but download failed. Very rare, should occur only with bad signal or maybe if message expires (needs investigation what happens if trying to redownload expired message). Redownload is allowed if not expired.
+        x-ubports-nuntium-mms-error-storage - the downloaded message file can't be saved to storage. Should happen only if disk full, or bad permissions (almost never). Redownload is NOT allowed (maybe should be?).
+        x-ubports-nuntium-mms-error-forward - everything went ok, but for some unexplained reason, can't forward the message to telepathy-ofono. But if that's the case, I'll be a miracle if the error message can be sent o telepathy-ofono, so should never happen. Redownload is NOT allowed.
+    Message [string] - raw error message caught in nuntium (just for debug purposes).
+    Expire [string, optional] - date-time in RFC3339 format, when the message expires in MMS service. If field not present, the Expire field was not sent by provider (how do we handle this?). Edit: However, if expiry time not provided by operator, we assume 7 days expiry time, so this field will not be empty ever (unless some bug).
+    Size [int, optional] - Size in bytes of message. If not present, size info was no sent by provider or size is 0.
+    MobileData [bool, optional] - if mobile data was enabled in the time of error handling. If not present, the mobile data property could not be determined.
+    */
+    onMessageStatusChanged: {
+        if (permanentError) {
+            errorTxt.text = permanentErrorText
+        } else {
+            var error = JSON.parse(textMessage)
+            if (error) {
+                if (error.Code === 'x-ubports-nuntium-mms-error-activate-context' && error.MobileData === false) {
+                    //display as standard message
+                    errorTxt.text = mmsReceivedText.arg(Math.round(error.Size/1000)).arg(Qt.formatDateTime(error.Expire))
+                } else {
+                    //for now display as temporary error
+                    errorTxt.text = temporaryErrorText
+                }
+
+                //deal with expired mms
+                var expireDate = Date.parse(error.Expire)
+                if (!isNaN(expireDate) && Date.now() > expireDate) {
+                    redownloadButton.enabled = false
+                }
+
+            } else {
+                //for now display as temporary error
+                errorTxt.text = temporaryErrorText
+            }
+        }
     }
 
     Image {
@@ -40,8 +91,7 @@ ListItemWithActions{
         sourceSize.height: units.gu(4)
         anchors {
             left: parent.left
-            top: parent.top
-            bottom: parent.bottom
+            verticalCenter: rectangle.verticalCenter
         }
     }
 
@@ -57,14 +107,13 @@ ListItemWithActions{
             left: image.right
             leftMargin: units.gu(1)
         }
-        height: errorTxt.height
+        height: errorTxt.height + redownloadButton.height + units.gu(1)
         width: units.gu(0.5)
         color: "red"
     }
 
     Label {
         id: errorTxt
-        text: i18n.tr("Oops, there has been an error with the MMS system and this message could not be retrieved. Please ensure Cellular Data is ON and MMS settings are correct, then ask the sender to try again.")
         fontSize: "medium"
         anchors {
             left: rectangle.right
@@ -88,10 +137,30 @@ ListItemWithActions{
         color: Theme.palette.normal.backgroundText
         elide: Text.ElideRight
         text: Qt.formatTime(messageData.timestamp, Qt.DefaultLocaleShortDate)
-
-
     }
 
+    Button {
+        id: redownloadButton
+        text: i18n.tr("Download")
+        visible: !permanentError
+        enabled: messageData.textMessageStatus === HistoryThreadModel.MessageStatusTemporarilyFailed
+
+        anchors {
+            top: errorTxt.bottom
+            topMargin: units.gu(1)
+            left: errorTxt.left
+        }
+
+        onClicked: function() {
+            chatManager.redownloadMessage(messageData.accountId, messageData.threadId, messageData.eventId)
+        }
+
+        ActivityIndicator {
+            id: indicator
+            anchors.centerIn: parent
+            running: messageData.textMessageStatus === HistoryThreadModel.MessageStatusPending
+        }
+    }
 
 
     leftSideAction: Action {
@@ -99,6 +168,10 @@ ListItemWithActions{
         iconName: "delete"
         text: i18n.tr("Delete")
         onTriggered: eventModel.removeEvents([messageData.properties]);
+    }
+
+    Component.onCompleted: {
+        console.log('textMessage:', textMessage)
     }
 
 }

--- a/src/qml/MessagesListView.qml
+++ b/src/qml/MessagesListView.qml
@@ -90,8 +90,8 @@ MultipleSelectionListView {
 
         Component.onCompleted: {
             var sourceFile = ""
-            var isMmsError = model.textMessageType === HistoryEventModel.MessageTypeMultiPart && model.textMessageAttachments.length === 0 && model.textMessage.length === 0
-            if (isMmsError) {
+            var isIncomingMmsError = model.senderId !== "self" && model.textMessageType === HistoryThreadModel.MessageTypeMultiPart && model.textMessageAttachments.length === 0 && (model.textMessage.length === 0 || model.textMessageStatus === HistoryThreadModel.MessageStatusTemporarilyFailed || model.textMessageStatus === HistoryThreadModel.MessageStatusPermanentlyFailed || model.textMessageStatus === HistoryThreadModel.MessageStatusPending)
+            if (isIncomingMmsError) {
                 sourceFile = "MessageAlertBubble.qml"
             } else if (textMessageType == HistoryThreadModel.MessageTypeInformation) {
                 sourceFile = "AccountSectionDelegate.qml"

--- a/src/qml/ThreadDelegate.qml
+++ b/src/qml/ThreadDelegate.qml
@@ -33,8 +33,8 @@ ListItemWithActions {
 
     property QtObject chatEntry: null
     property bool compactView: false
-    property bool isEmptyMMS: eventTextMessageType === HistoryEventModel.MessageTypeMultiPart && displayedEventTextAttachments.length === 0 && eventTextMessage.length === 0
-    property string defaultMMSErrorMessage: i18n.tr("Oops, there has been an error with the MMS system and this message could not be retrieved. Please ensure Cellular Data is ON and MMS settings are correct, then ask the sender to try again.")
+    property bool isIncomingMmsError: eventSenderId !== "self" && eventTextMessageType === HistoryEventModel.MessageTypeMultiPart && displayedEventTextAttachments.length === 0 && (eventTextMessage.length === 0 || eventTextMessageStatus === HistoryEventModel.MessageStatusTemporarilyFailed || eventTextMessageStatus === HistoryEventModel.MessageStatusPermanentlyFailed || eventTextMessageStatus === HistoryEventModel.MessageStatusPending)
+    property string defaultMMSErrorMessage: i18n.tr("New MMS notification")
     property var participant: participants ? participants[0] : {}
     property bool groupChat: chatType == HistoryThreadModel.ChatTypeRoom || participants.length > 1
     property string searchTerm
@@ -124,7 +124,7 @@ ListItemWithActions {
         if (attachmentCount > 0) {
             return i18n.tr("Attachment: %1 file", "Attachments: %1 files").arg(attachmentCount)
         }
-        if(isEmptyMMS) {
+        if(isIncomingMmsError) {
             return defaultMMSErrorMessage
         }
 
@@ -358,12 +358,12 @@ ListItemWithActions {
 
         Image {
             id: mmsErrorImg
-            visible: isEmptyMMS
+            visible: isIncomingMmsError
             source: "image://theme/mail-mark-important"
             anchors.verticalCenter: latestMessage.verticalCenter
             sourceSize.height: units.gu(2)
             layer {
-                enabled: isEmptyMMS
+                enabled: isIncomingMmsError
                 effect: ColorOverlay {
                     color: "red"
                 }


### PR DESCRIPTION
Notify user when a MMS arrived but can't be read and add the ability to download it afterward.

For the long story: 
https://forums.ubports.com/topic/5100/the-mms-lost-story/110


Add redownload button to failed MMS bubble
- Redownload button visibility and enabled depends on status
- Error message text depends on button visibilty
- Some error details are in message text encoded in json (Description, Expiry, Size)

Prerequisites: Folowing PR's need to be merged to make this work ubports/nuntium#8, ubports/telepathy-ofono#20, [gitlab/ubports/core/history-service#8](https://gitlab.com/ubports/core/history-service/-/merge_requests/8) and ubports/telephony-service#20

fixes https://github.com/ubports/messaging-app/issues/17
fixes https://github.com/ubports/ubuntu-touch/issues/1408
fixes https://github.com/ubports/ubuntu-touch/issues/239