### PR TITLE
Add read permission to qt shader cache

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+messaging-app (0.1.3~0ubports1) xenial; urgency=medium
+
+  * Add qt shader cache read access in apparmor profile
+
+ -- José Pekkarinen <jose.pekkarinen@foxhound.fi>  Sat, 18 Sep 2021 12:58:21 +0300
+
 messaging-app (0.1.3~0ubports0) xenial; urgency=medium
 
   * Removed leadingActions from MessagingContactViewPage

--- a/debian/messaging-app-apparmor.manifest
+++ b/debian/messaging-app-apparmor.manifest
@@ -27,8 +27,10 @@
         "/usr/share/applications/",
         "/custom/xdg/data/dconf/",
         "/usr/share/*/assets/",
+        "@{PROC}/[0-9]*/task/[0-9]*/comm",
         "@{HOME}/.local/share/evolution/addressbook/*/photos/",
         "@{HOME}/.cache/messaging-app/HubIncoming/**",
+        "@{HOME}/.cache/qtshadercache-arm64-little_endian-lp64/**",
         "@{HOME}/.config/dconf/user",
         "/usr/share/messaging-app/"
       ]


### PR DESCRIPTION
This patch adds the apparmor profile permissions
to solve the following couple of denials. Observed
while trying to send a picture over mms on messaging-app.

Sep 18 15:04:29 ubuntu-phablet kernel: [  236.994726] audit: type=1400 audit(1631966669.681:168): apparmor="DENIED" operation="open" profile="messaging-app" name="/proc/6307/task/6346/comm" pid=6307 comm="QSGRenderThread" requested_mask="r" denied_mask="r" fsuid=32011 ouid=32011
[  210.312281] audit: type=1400 audit(1631966643.001:136): apparmor="DENIED" operation="open" profile="messaging-app" name="/home/phablet/.cache/qtshadercache-arm64-little_endian-lp64/deeaa96ac50287ecfebcec7dc60134256be0011c" pid=6307 comm="QSGRenderThread" requested_mask="r" denied_mask="r" fsuid=32011 ouid=32011

Signed-off-by: José Pekkarinen <jose.pekkarinen@foxhound.fi>