### PR TITLE
display full image

### DIFF
--- a/src/qml/AttachmentDelegates/AnimatedImageDelegate.qml
+++ b/src/qml/AttachmentDelegates/AnimatedImageDelegate.qml
@@ -19,14 +19,15 @@
 import QtQuick 2.2
 import QtQuick.Controls 2.2
 import Ubuntu.Components 1.3
+import QtGraphicalEffects 1.0
 import ".."
 
 BaseDelegate {
     id: imageDelegate
 
     previewer: "AttachmentDelegates/PreviewerImage.qml"
-    height: imageAttachment.height
-    width: imageAttachment.width
+    height: bubble.height + messageFooter.height + units.gu(0.5)
+    width: bubble.width
 
     function calculateVisibility() {
         // check if item is truly visible
@@ -40,7 +41,7 @@ BaseDelegate {
                 attachment.played = true
                 // prevent from infinite playing
                 autoStopAnimation.start()
-             }
+            }
         } else {
             imageAttachment.playing = false
             autoStopAnimation.stop()
@@ -76,9 +77,6 @@ BaseDelegate {
         onTriggered: imageAttachment.playing = false
     }
 
-    property bool isFullyVisible: (yoff > list.y && yoff + height < list.y + list.height)
-
-
     UbuntuShape {
         id: bubble
         anchors.top: parent.top
@@ -89,12 +87,12 @@ BaseDelegate {
             id: imageAttachment
             objectName: "imageAttachment"
 
-            fillMode: Image.PreserveAspectCrop
+            fillMode: Image.PreserveAspectFit
             playing: false
             source: attachment.filePath
-            asynchronous: true
-            height: units.gu(14)
-            width:units.gu(27)
+            asynchronous: messageList.moving ? true: false
+            height: units.gu(27)
+            width: units.gu(27)
             cache: false
 
             onStatusChanged:  {
@@ -112,12 +110,11 @@ BaseDelegate {
             id: playbackBtn
             anchors {
                 right: imageAttachment.right
-                bottom: imageFooter.top
-                rightMargin: units.gu(1)
+                bottom: imageAttachment.bottom
+                rightMargin: units.gu(0.5)
             }
             width: units.gu(3)
             height: width
-            backgroundColor: Qt.rbga(255,255,255)
             radius: "large"
 
             Icon {
@@ -127,52 +124,41 @@ BaseDelegate {
 
             MouseArea {
                 anchors.fill: parent
-                onPressed: {
-                    imageAttachment.playing ? imageAttachment.playing = false: imageAttachment.playing = true
-                }
+                onPressed: imageAttachment.playing = !imageAttachment.playing
             }
-
         }
 
-
-        Rectangle {
-            id: imageFooter
+        Row {
+            id: messageFooter
             visible: imageDelegate.lastItem
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "transparent" }
-                GradientStop { position: 1.0; color: "gray" }
-            }
+            spacing: units.gu(1)
 
             anchors {
-                bottom: parent.bottom
-                left: parent.left
+                top: parent.bottom
+                topMargin: units.gu(0.5)
                 right: parent.right
+                rightMargin: units.gu(1)
             }
-            height: units.gu(2)
-            radius: bubble.height * 0.1
+
             Label {
-                anchors{
-                    left: parent.left
-                    bottom: parent.bottom
-                    leftMargin: incoming ? units.gu(2) : units.gu(1)
-                    bottomMargin: units.gu(0.5)
-                }
+                id: dateLbl
+                anchors.bottom: parent.bottom
                 fontSize: "xx-small"
                 text: Qt.formatTime(timestamp).toLowerCase()
-                color: "white"
+            }
+
+            DeliveryStatus {
+                id: deliveryStatus
+                anchors.verticalCenter: dateLbl.verticalCenter
+                messageStatus: textMessageStatus
+                enabled: showDeliveryStatus
+
+                ColorOverlay {
+                    anchors.fill: deliveryStatus
+                    source: deliveryStatus
+                    color: dateLbl.color
+                }
             }
         }
-    }
-
-    DeliveryStatus {
-       id: deliveryStatus
-       messageStatus: textMessageStatus
-       enabled: showDeliveryStatus
-       anchors {
-           right: parent.right
-           rightMargin: units.gu(0.5)
-           bottom: parent.bottom
-           bottomMargin: units.gu(0.5)
-       }
     }
 }

--- a/src/qml/AttachmentDelegates/ImageDelegate.qml
+++ b/src/qml/AttachmentDelegates/ImageDelegate.qml
@@ -18,36 +18,33 @@
 
 import QtQuick 2.2
 import Ubuntu.Components 1.3
+import QtGraphicalEffects 1.0
 import ".."
 
 BaseDelegate {
     id: imageDelegate
 
     previewer: "AttachmentDelegates/PreviewerImage.qml"
-    height: imageAttachment.height
-    width: imageAttachment.width
+    height: bubble.height + messageFooter.height + units.gu(0.5)
+    width: bubble.width
 
     UbuntuShape {
         id: bubble
         anchors.top: parent.top
-        width: image.width
-        height: image.height
+        width: imageAttachment.width
+        height: imageAttachment.height
 
         image: Image {
             id: imageAttachment
             objectName: "imageAttachment"
-
-            fillMode: Image.PreserveAspectCrop
+            fillMode: Image.PreserveAspectFit
             smooth: true
             source: attachment.filePath
             visible: false
-            asynchronous: true
-            height: Math.min(implicitHeight, units.gu(14))
+            asynchronous: messageList.moving ? true: false
             width: Math.min(implicitWidth, units.gu(27))
             cache: false
-
             sourceSize.width: units.gu(27)
-            sourceSize.height: units.gu(27)
 
             onStatusChanged:  {
                 if (status === Image.Error) {
@@ -56,45 +53,39 @@ BaseDelegate {
                     height = 128
                 }
             }
-        }
+        }      
 
-        Rectangle {
+        Row {
+            id: messageFooter
             visible: imageDelegate.lastItem
-            gradient: Gradient {
-                GradientStop { position: 0.0; color: "transparent" }
-                GradientStop { position: 1.0; color: "gray" }
-            }
+            spacing: units.gu(1)
 
             anchors {
-                bottom: parent.bottom
-                left: parent.left
+                top: parent.bottom
+                topMargin: units.gu(0.5)
                 right: parent.right
+                rightMargin: units.gu(1)
             }
-            height: units.gu(2)
-            radius: bubble.height * 0.1
+
             Label {
-                anchors{
-                    left: parent.left
-                    bottom: parent.bottom
-                    leftMargin: incoming ? units.gu(2) : units.gu(1)
-                    bottomMargin: units.gu(0.5)
-                }
+                id: dateLbl
+                anchors.bottom: parent.bottom
                 fontSize: "xx-small"
                 text: Qt.formatTime(timestamp).toLowerCase()
-                color: "white"
+            }
+
+            DeliveryStatus {
+               id: deliveryStatus
+               anchors.verticalCenter: dateLbl.verticalCenter
+               messageStatus: textMessageStatus
+               enabled: showDeliveryStatus
+
+               ColorOverlay {
+                   anchors.fill: deliveryStatus
+                   source: deliveryStatus
+                   color: dateLbl.color
+               }
             }
         }
-    }
-
-    DeliveryStatus {
-       id: deliveryStatus
-       messageStatus: textMessageStatus
-       enabled: showDeliveryStatus
-       anchors {
-           right: parent.right
-           rightMargin: units.gu(0.5)
-           bottom: parent.bottom
-           bottomMargin: units.gu(0.5)
-       }
     }
 }


### PR DESCRIPTION
Today, images are cropped and not easily readable:

![screenshot20211230_160818965](https://user-images.githubusercontent.com/11663835/147763951-c085a12c-ee18-478b-9bdb-8c562eee7c78.png)


The idea is to paint them so that we can see the whole picture:

![screenshot20211230_161023938](https://user-images.githubusercontent.com/11663835/147763977-5b77a74a-c501-44f4-a113-e02c90462feb.png)


fixes: #243
fixes: #318

Click test package available here: arm64: https://github.com/lduboeuf/messaging-app/suites/4814619336/artifacts/135579936
armhf: https://github.com/lduboeuf/messaging-app/suites/4814619336/artifacts/135579937