### PR TITLE
Do not display attachments icons when MMS is disabled

### DIFF
--- a/src/qml/Messages.qml
+++ b/src/qml/Messages.qml
@@ -1651,7 +1651,15 @@ Page {
         presenceRequest: messages.presenceRequest
         isBroadcast: messages.isBroadcast
         returnToSend: messages.account && messages.account.protocolInfo.returnToSend
-        enableAttachments: messages.account && messages.account.protocolInfo.enableAttachments
+        enableAttachments: {
+            if (messages.account) {
+                if (messages.account.protocolInfo.name === "ofono") {
+                    return messages.account.protocolInfo.enableAttachments && telepathyHelper.mmsEnabled
+                } else {
+                    return messages.account.protocolInfo.enableAttachments
+                }
+            }
+        }
 
         showContents: !selectionMode && !isSearching && !chatInactiveLabel.visible
         maxHeight: messages.height - keyboard.height - screenTop.y


### PR DESCRIPTION
fixes https://github.com/ubports/messaging-app/issues/278

to test: Disable MMS in messaging-app settings, you should not see attachment, sticker or audio icon in the compose bar:

![screenshot20220427_103809122](https://user-images.githubusercontent.com/11663835/165478100-d2d99cdb-dcc9-4a75-819e-d52c5d09f429.png)






