### PR TITLE
Add Pinch to zoom text in conversation view

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -62,7 +62,7 @@ ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
 ifneq (,$(filter $(DEB_HOST_ARCH),$(testskip_architectures)))
 	-dh_auto_test
 else
-	dh_auto_test
+	CTEST_OUTPUT_ON_FAILURE=1 dh_auto_test
 endif
 endif
 

--- a/src/qml/ComposeBar.qml
+++ b/src/qml/ComposeBar.qml
@@ -474,6 +474,7 @@ Flickable {
                 property bool autoCompleteLock: false
 
                 property int autoCompleteStartIndex: -1
+                property real fontSize: FontUtils.sizeToPixels(mainView.scaledFontSize)
 
                 function updateAutoComplete(startIndex, input)
                 {
@@ -558,7 +559,7 @@ Flickable {
                 Keys.onReturnPressed: event.accepted = returnPressed()
                 Keys.onEnterPressed: event.accepted = returnPressed()
                 // this value is to avoid letter being cut off
-                height: units.gu(4.3)
+                height: fontSize * 2.2
                 style: LocalTextAreaStyle {}
                 autoSize: true
                 maximumLineCount: attachments.count == 0 ? 8 : 4
@@ -580,7 +581,7 @@ Flickable {
                 }
                 focus: textEntry.focus
                 font.family: "Ubuntu"
-                font.pixelSize: FontUtils.sizeToPixels("medium")
+                font.pixelSize: fontSize
                 color: Theme.palette.normal.backgroundText
                 Keys.onPressed: {
                     if (event.key === Qt.Key_Tab) {

--- a/src/qml/MessageBubble.qml
+++ b/src/qml/MessageBubble.qml
@@ -109,6 +109,10 @@ Item {
                               senderName.contentWidth))
             + units.gu(3)
 
+    Behavior on height {
+        NumberAnimation {}
+    }
+
     // if possible, put the timestamp and the delivery status in the same line as the text
     property int oneLineWidth: textLabel.implicitWidth + messageFooter.width
     property bool oneLine: oneLineWidth <= maxDelegateWidth
@@ -145,7 +149,7 @@ Item {
                 leftMargin: units.gu(1)
                 rightMargin: units.gu(1)
             }
-            fontSize: "medium"
+            fontSize: mainView.scaledFontSize
             onLinkActivated:  Qt.openUrlExternally(link)
             text: root.parseText(messageText)
             width: root.oneLine ? implicitWidth : maxDelegateWidth

--- a/src/qml/Messages.qml
+++ b/src/qml/Messages.qml
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import QtQuick 2.2
+import QtQuick 2.12
 import QtQuick.Window 2.0
 import Ubuntu.Components 1.3
 import Ubuntu.Components.ListItems 1.3 as ListItem
@@ -1518,6 +1518,47 @@ Page {
             right: parent.right
         }
         height: 0
+    }
+
+    PinchHandler {
+        id: pinchHandler
+        target: null
+
+        minimumPointCount: 2
+        maximumScale: 3
+
+        property real previousScale: 1.0
+        property real zoomThreshold: 0.5
+
+        onScaleChanged: {
+
+            var nextLevel = mainView.scaleLevel
+            if (activeScale > previousScale + zoomThreshold && nextLevel < maximumScale) { // zoom in
+                nextLevel++
+            } else if (activeScale < previousScale - zoomThreshold && nextLevel > 0) { // zoom out
+                nextLevel--
+            }
+
+            if (nextLevel !== mainView.scaleLevel) {
+
+                mainView.scaleLevel = nextLevel
+
+                 // get the index of the current drag item if any and make ListView follow it
+                var positionInRoot = mapToItem(messageList.contentItem, centroid.position.x, centroid.position.y)
+                const currentIndex = messageList.indexAt(positionInRoot.x,positionInRoot.y)
+
+                messageList.positionViewAtIndex(currentIndex, ListView.Visible)
+
+                previousScale = activeScale
+            }
+        }
+
+        onActiveChanged: {
+            if (active) {
+                previousScale = 1.0
+                messageList.currentIndex = -1
+            }
+        }
     }
 
     MessagesListView {

--- a/src/qml/messaging-app.qml
+++ b/src/qml/messaging-app.qml
@@ -45,10 +45,13 @@ MainView {
     property alias autoplayAnimatedImage: globalSettings.autoplayAnimatedImage
     property alias enableStickers: globalSettings.enableStickers
     property alias autoPopupKeyboard: globalSettings.autoPopupKeyboard
+    property alias scaleLevel: globalSettings.scaleLevel
+
+    readonly property variant fontSizeNames: ["small", "medium", "large", "x-large"]
+    readonly property string scaledFontSize: fontSizeNames[scaleLevel]
 
     // private
     property var _pendingProperties: null
-
 
     function updateNewMessageStatus() {
         activeMessagesView = application.findMessagingChild("messagesPage", "active", true)
@@ -294,6 +297,7 @@ MainView {
         property bool autoplayAnimatedImage: true
         property bool enableStickers: true
         property bool autoPopupKeyboard: true
+        property int scaleLevel: 1
     }
 
     Connections {


### PR DESCRIPTION
This allows to increase/decrease font size in conversation view with a Pinch gesture.
Font size also persist during restart.

To  test: in conversation view, Pinch to zoom in the middle of the screen. Text size should increase or decrease ( only 4 level allowed ).
It persist retween restart

Test click file here: 
[messaging-app.ubports_0.0.0+testing-click-build_armhf.zip](https://github.com/ubports/messaging-app/files/9525547/messaging-app.ubports_0.0.0%2Btesting-click-build_armhf.zip)
[messaging-app.ubports_0.0.0+testing-click-build_arm64.zip](https://github.com/ubports/messaging-app/files/9525549/messaging-app.ubports_0.0.0%2Btesting-click-build_arm64.zip)

