### PR TITLE
debian: bump dependency to apparmor-easyprof-ubuntu

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+messaging-app (0.1.4) xenial; urgency=medium
+
+  * debian/control: bump dependency to apparmor-easyprof-ubuntu
+
+ -- Alberto Mardegan <mardy@users.sourceforge.net>  Wed, 14 Sep 2022 22:04:34 +0300
+
 messaging-app (0.1.3~0ubports0) xenial; urgency=medium
 
   * Removed leadingActions from MessagingContactViewPage

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Ubuntu Developers <ubuntu-devel-discuss@lists.ubuntu.com>
 Build-Depends:
  apparmor-easyprof:all,
- apparmor-easyprof-ubuntu:all (>= 1.3.13),
+ apparmor-easyprof-ubuntu:all (>= 16.10.5),
  apparmor:native,
  cmake,
  debhelper (>= 9),


### PR DESCRIPTION
This is to trigger a rebuild, and ensure that the latest version of the apparmor profile is used.

Fixes: #351 